### PR TITLE
Refactor configuration defaults and decouple gear computations

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,28 @@
+{
+  "window": {
+    "title": "FGPG - Fine Gear Profile Generator (Refactored)",
+    "geometry": "950x700"
+  },
+  "defaults": {
+    "module_m": 1.0,
+    "teeth_number_z": 18,
+    "pressure_angle_alpha": 20.0,
+    "offset_factor_x": 0.2,
+    "backlash_factor_b": 0.05,
+    "addendum_factor_a": 1.0,
+    "dedendum_factor_d": 1.25,
+    "hob_edge_radius_c": 0.2,
+    "tooth_edge_radius_e": 0.1,
+    "teeth_number_z2": 36,
+    "offset_factor_x2": 0.0,
+    "x_0": 0.0,
+    "y_0": 0.0,
+    "seg_involute": 15,
+    "seg_edge_r": 15,
+    "seg_root_r": 15,
+    "seg_outer": 5,
+    "seg_root": 5,
+    "working_directory": "./result/",
+    "current_image_path": "Result1.png"
+  }
+}

--- a/fine_gear_profile_generator/core/gear_core.py
+++ b/fine_gear_profile_generator/core/gear_core.py
@@ -1,0 +1,56 @@
+"""Core calculation orchestrator for the Fine Gear Profile Generator."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from . import gear_math, geometry_generator
+
+
+def generate_gear_pair(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Compute all derived data required to describe a gear pair."""
+    contact_ratio, center_dist = gear_math.calculate_contact_ratio(
+        params['M'],
+        params['Z'],
+        params['z2'],
+        params['X'],
+        params['x2'],
+        params['ALPHA'],
+        params['A']
+    )
+
+    undercut_status1 = gear_math.check_undercut(
+        params['Z'], params['ALPHA'], params['X'], params['A']
+    )
+    undercut_status2 = gear_math.check_undercut(
+        params['z2'], params['ALPHA'], params['x2'], params['A']
+    )
+
+    gear1_profile = geometry_generator.generate_tooth_profile(
+        params['M'], params['Z'], params['ALPHA'], params['X'], params['B'],
+        params['A'], params['D'], params['C'], params['E'],
+        params['SEG_INVOLUTE'], params['SEG_EDGE_R'], params['SEG_ROOT_R'],
+        params['SEG_OUTER'], params['SEG_ROOT']
+    )
+
+    gear2_profile = geometry_generator.generate_tooth_profile(
+        params['M'], params['z2'], params['ALPHA'], params['x2'], params['B'],
+        params['A'], params['D'], params['C'], params['E'],
+        params['SEG_INVOLUTE'], params['SEG_EDGE_R'], params['SEG_ROOT_R'],
+        params['SEG_OUTER'], params['SEG_ROOT']
+    )
+
+    return {
+        'analysis': {
+            'contact_ratio': contact_ratio,
+            'center_distance': center_dist,
+        },
+        'gear1': {
+            'profile': gear1_profile,
+            'undercut_status': undercut_status1,
+        },
+        'gear2': {
+            'profile': gear2_profile,
+            'undercut_status': undercut_status2,
+        },
+    }

--- a/fine_gear_profile_generator/core/gear_math.py
+++ b/fine_gear_profile_generator/core/gear_math.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+FULL_TURN = 2 * np.pi
+RIGHT_ANGLE = np.pi / 2
+
 def inv(alpha_rad):
     """Calculates the involute function (tan(a) - a)"""
     return np.tan(alpha_rad) - alpha_rad
@@ -76,8 +79,11 @@ def calculate_gear_parameters(M, Z, ALPHA, X, B, A, D, C, E):
     This function is complex and seems highly specific to the generating process.
     """
     ALPHA_0 = np.deg2rad(ALPHA)
-    ALPHA_M = np.pi / Z
-    ALPHA_IS = ALPHA_0 + np.pi / (2 * Z) + B / (Z * np.cos(ALPHA_0)) - (1 + 2 * X / Z) * np.sin(ALPHA_0) / np.cos(ALPHA_0)
+    TOOTH_CENTER_ANGLE = np.pi / Z
+    HALF_TOOTH_CENTER_ANGLE = TOOTH_CENTER_ANGLE / 2
+    PITCH_ANGLE = FULL_TURN / Z
+    ALPHA_M = TOOTH_CENTER_ANGLE
+    ALPHA_IS = ALPHA_0 + HALF_TOOTH_CENTER_ANGLE + B / (Z * np.cos(ALPHA_0)) - (1 + 2 * X / Z) * np.sin(ALPHA_0) / np.cos(ALPHA_0)
     THETA_IS = np.tan(ALPHA_0) + 2 * (C * (1 - np.sin(ALPHA_0)) + X - D) / (Z * np.cos(ALPHA_0) * np.sin(ALPHA_0))
 
     sqrt_val_ie = ((Z + 2 * (X + A - E)) / (Z * np.cos(ALPHA_0)))**2 - 1
@@ -96,7 +102,6 @@ def calculate_gear_parameters(M, Z, ALPHA, X, B, A, D, C, E):
             sqrt_val_e = 0
         E = (E / 2) * np.cos(ALPHA_0) * (THETA_IE - np.sqrt(sqrt_val_e))
 
-    P_ANGLE = 2 * np.pi / Z
-    ALIGN_ANGLE = np.pi / 2 - np.pi / Z
+    ALIGN_ANGLE = RIGHT_ANGLE - TOOTH_CENTER_ANGLE
 
-    return ALPHA_0, ALPHA_M, ALPHA_IS, THETA_IS, THETA_IE, ALPHA_E, E, P_ANGLE, ALIGN_ANGLE
+    return ALPHA_0, ALPHA_M, ALPHA_IS, THETA_IS, THETA_IE, ALPHA_E, E, PITCH_ANGLE, ALIGN_ANGLE

--- a/fine_gear_profile_generator/utils/config_manager.py
+++ b/fine_gear_profile_generator/utils/config_manager.py
@@ -1,6 +1,106 @@
 import json
 import os
 
+DEFAULT_CONFIG_FILENAME = 'config.json'
+
+FALLBACK_DEFAULTS = {
+    'module_m': 1.0,
+    'teeth_number_z': 18,
+    'pressure_angle_alpha': 20.0,
+    'offset_factor_x': 0.2,
+    'backlash_factor_b': 0.05,
+    'addendum_factor_a': 1.0,
+    'dedendum_factor_d': 1.25,
+    'hob_edge_radius_c': 0.2,
+    'tooth_edge_radius_e': 0.1,
+    'teeth_number_z2': 36,
+    'offset_factor_x2': 0.0,
+    'x_0': 0.0,
+    'y_0': 0.0,
+    'seg_involute': 15,
+    'seg_edge_r': 15,
+    'seg_root_r': 15,
+    'seg_outer': 5,
+    'seg_root': 5,
+    'working_directory': './result/',
+    'current_image_path': 'Result1.png'
+}
+
+UI_TO_CALCULATION_MAP = {
+    'module_m': 'M',
+    'teeth_number_z': 'Z',
+    'pressure_angle_alpha': 'ALPHA',
+    'offset_factor_x': 'X',
+    'backlash_factor_b': 'B',
+    'addendum_factor_a': 'A',
+    'dedendum_factor_d': 'D',
+    'hob_edge_radius_c': 'C',
+    'tooth_edge_radius_e': 'E',
+    'x_0': 'X_0',
+    'y_0': 'Y_0',
+    'seg_involute': 'SEG_INVOLUTE',
+    'seg_edge_r': 'SEG_EDGE_R',
+    'seg_root_r': 'SEG_ROOT_R',
+    'seg_outer': 'SEG_OUTER',
+    'seg_root': 'SEG_ROOT',
+    'teeth_number_z2': 'z2',
+    'offset_factor_x2': 'x2'
+}
+
+INT_PARAM_KEYS = {
+    'Z', 'SEG_INVOLUTE', 'SEG_EDGE_R', 'SEG_ROOT_R', 'SEG_OUTER',
+    'SEG_ROOT', 'z2'
+}
+
+
+def get_config_path(filename: str = DEFAULT_CONFIG_FILENAME):
+    """Return the absolute path to the application configuration file."""
+    package_root = os.path.dirname(os.path.dirname(__file__))
+    project_root = os.path.dirname(package_root)
+    return os.path.join(project_root, filename)
+
+
+def load_app_config(path: str = None):
+    """Load application configuration data from JSON."""
+    config_path = path or get_config_path()
+    if not os.path.exists(config_path):
+        return {}
+    try:
+        with open(config_path, 'r') as file:
+            return json.load(file)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def get_defaults(config_data: dict = None):
+    """Return merged default values using configuration data with fallbacks."""
+    config = config_data or load_app_config()
+    defaults = dict(FALLBACK_DEFAULTS)
+    defaults.update(config.get('defaults', {}))
+    return defaults
+
+
+def get_default_calculation_params(config_data: dict = None):
+    """Map UI default values to the calculation parameter schema."""
+    defaults = get_defaults(config_data)
+    calculation_params = {}
+    for ui_key, calc_key in UI_TO_CALCULATION_MAP.items():
+        if ui_key in defaults:
+            calculation_params[calc_key] = defaults[ui_key]
+
+    for key in INT_PARAM_KEYS:
+        if key in calculation_params:
+            calculation_params[key] = int(calculation_params[key])
+
+    return calculation_params
+
+
+def get_default_working_directory(config_data: dict = None):
+    """Return the default working directory specified in the configuration."""
+    defaults = get_defaults(config_data)
+    return defaults.get('working_directory', FALLBACK_DEFAULTS['working_directory'])
+
+
 def save_params(working_dir, params_dict):
     """
     Saves a dictionary of parameters to Inputs.dat in the specified directory.


### PR DESCRIPTION
## Summary
- move GUI default values into a shared config.json and load them through the config manager
- introduce a core.gear_core module that returns reusable calculation results and update the GUI and headless runner to consume it
- replace magic numbers in gear_math with descriptive constants for clarity

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e66e9536108328aa1b417cc6ddfc55