### PR TITLE
Enhance documentation and introduce gear parameter dataclasses

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,28 @@
+{
+  "window": {
+    "title": "FGPG - Fine Gear Profile Generator (Refactored)",
+    "geometry": "950x700"
+  },
+  "defaults": {
+    "module_m": 1.0,
+    "teeth_number_z": 18,
+    "pressure_angle_alpha": 20.0,
+    "offset_factor_x": 0.2,
+    "backlash_factor_b": 0.05,
+    "addendum_factor_a": 1.0,
+    "dedendum_factor_d": 1.25,
+    "hob_edge_radius_c": 0.2,
+    "tooth_edge_radius_e": 0.1,
+    "teeth_number_z2": 36,
+    "offset_factor_x2": 0.0,
+    "x_0": 0.0,
+    "y_0": 0.0,
+    "seg_involute": 15,
+    "seg_edge_r": 15,
+    "seg_root_r": 15,
+    "seg_outer": 5,
+    "seg_root": 5,
+    "working_directory": "./result/",
+    "current_image_path": "Result1.png"
+  }
+}

--- a/fine_gear_profile_generator/core/gear_core.py
+++ b/fine_gear_profile_generator/core/gear_core.py
@@ -1,0 +1,84 @@
+"""Core calculation orchestrator for the Fine Gear Profile Generator."""
+
+from __future__ import annotations
+
+from typing import Dict, Union
+
+from . import gear_math, geometry_generator
+from .models import (
+    GearPairAnalysis,
+    GearPairParameters,
+    GearPairResult,
+    GearProfileGeometry,
+)
+
+
+def _resolve_parameters(
+    params: Union[GearPairParameters, Dict[str, float]],
+) -> GearPairParameters:
+    """Normalize legacy dictionaries into ``GearPairParameters`` instances."""
+
+    if isinstance(params, GearPairParameters):
+        return params
+    return GearPairParameters.from_dict(params)
+
+
+def generate_gear_pair(
+    params: Union[GearPairParameters, Dict[str, float]],
+) -> GearPairResult:
+    """Compute all derived geometry and analysis data for the supplied gear pair."""
+
+    normalized_params = _resolve_parameters(params)
+    calc_params = normalized_params.to_calculation_dict()
+
+    contact_ratio, center_dist = gear_math.calculate_contact_ratio(
+        calc_params['M'],
+        calc_params['Z'],
+        calc_params['z2'],
+        calc_params['X'],
+        calc_params['x2'],
+        calc_params['ALPHA'],
+        calc_params['A']
+    )
+
+    undercut_status1 = gear_math.check_undercut(
+        calc_params['Z'], calc_params['ALPHA'], calc_params['X'], calc_params['A']
+    )
+    undercut_status2 = gear_math.check_undercut(
+        calc_params['z2'], calc_params['ALPHA'], calc_params['x2'], calc_params['A']
+    )
+
+    gear1_profile = geometry_generator.generate_tooth_profile(
+        calc_params['M'], calc_params['Z'], calc_params['ALPHA'], calc_params['X'], calc_params['B'],
+        calc_params['A'], calc_params['D'], calc_params['C'], calc_params['E'],
+        calc_params['SEG_INVOLUTE'], calc_params['SEG_EDGE_R'], calc_params['SEG_ROOT_R'],
+        calc_params['SEG_OUTER'], calc_params['SEG_ROOT']
+    )
+
+    gear2_profile = geometry_generator.generate_tooth_profile(
+        calc_params['M'], calc_params['z2'], calc_params['ALPHA'], calc_params['x2'], calc_params['B'],
+        calc_params['A'], calc_params['D'], calc_params['C'], calc_params['E'],
+        calc_params['SEG_INVOLUTE'], calc_params['SEG_EDGE_R'], calc_params['SEG_ROOT_R'],
+        calc_params['SEG_OUTER'], calc_params['SEG_ROOT']
+    )
+
+    return GearPairResult(
+        analysis=GearPairAnalysis(
+            contact_ratio=contact_ratio,
+            center_distance=center_dist,
+        ),
+        gear1=GearProfileGeometry(
+            coordinates=(gear1_profile[0], gear1_profile[1]),
+            teeth=int(gear1_profile[2]),
+            pitch_angle=float(gear1_profile[3]),
+            alignment_angle=float(gear1_profile[4]),
+            undercut_status=undercut_status1,
+        ),
+        gear2=GearProfileGeometry(
+            coordinates=(gear2_profile[0], gear2_profile[1]),
+            teeth=int(gear2_profile[2]),
+            pitch_angle=float(gear2_profile[3]),
+            alignment_angle=float(gear2_profile[4]),
+            undercut_status=undercut_status2,
+        ),
+    )

--- a/fine_gear_profile_generator/core/gear_math.py
+++ b/fine_gear_profile_generator/core/gear_math.py
@@ -1,102 +1,164 @@
+"""Mathematical utilities used by the gear generation engine."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
 import numpy as np
 
-def inv(alpha_rad):
-    """Calculates the involute function (tan(a) - a)"""
-    return np.tan(alpha_rad) - alpha_rad
+FULL_TURN = 2 * np.pi
+RIGHT_ANGLE = np.pi / 2
 
-def calculate_operating_pressure_angle(z1, z2, x1, x2, alpha_deg):
-    """Calculates the operating pressure angle."""
+
+def inv(alpha_rad: float) -> float:
+    """Calculate the involute function for the provided angle in radians."""
+
+    return float(np.tan(alpha_rad) - alpha_rad)
+
+
+def calculate_operating_pressure_angle(
+    z1: int,
+    z2: int,
+    x1: float,
+    x2: float,
+    alpha_deg: float,
+) -> float:
+    """Determine the operating pressure angle for a meshing gear pair."""
+
     alpha_rad = np.deg2rad(alpha_deg)
     inv_alpha_w = inv(alpha_rad) + 2 * (x1 + x2) * np.tan(alpha_rad) / (z1 + z2)
-    # Using a simple iterative solver to find the angle from its involute
-    alpha_w = alpha_rad  # Start with the standard pressure angle as an initial guess
-    for _ in range(10): # 10 iterations are usually more than enough
-        f = inv(alpha_w) - inv_alpha_w
-        f_prime = np.tan(alpha_w)**2
-        if abs(f_prime) < 1e-9:  # Avoid division by zero
+    alpha_w = alpha_rad
+    for _ in range(10):
+        function_val = inv(alpha_w) - inv_alpha_w
+        derivative = np.tan(alpha_w) ** 2
+        if abs(derivative) < 1e-9:
             break
-        alpha_w = alpha_w - f / f_prime
-    return alpha_w
+        alpha_w = alpha_w - function_val / derivative
+    return float(alpha_w)
 
-def calculate_contact_ratio(m, z1, z2, x1, x2, alpha_deg, a1=1.0):
-    """Calculates the contact ratio for a pair of spur gears."""
+
+def calculate_contact_ratio(
+    module: float,
+    z1: int,
+    z2: int,
+    x1: float,
+    x2: float,
+    alpha_deg: float,
+    a1: float = 1.0,
+) -> Tuple[float, float]:
+    """Calculate the contact ratio and center distance for a gear pair."""
+
     alpha_rad = np.deg2rad(alpha_deg)
     alpha_w_rad = calculate_operating_pressure_angle(z1, z2, x1, x2, alpha_deg)
 
-    # Center distance modification due to profile shift
-    c = m * (z1 + z2) / 2 * (np.cos(alpha_rad) / np.cos(alpha_w_rad))
+    center_distance = module * (z1 + z2) / 2 * (np.cos(alpha_rad) / np.cos(alpha_w_rad))
 
-    # Base circle radii
-    rb1 = m * z1 * np.cos(alpha_rad) / 2
-    rb2 = m * z2 * np.cos(alpha_rad) / 2
+    base_radius_gear1 = module * z1 * np.cos(alpha_rad) / 2
+    base_radius_gear2 = module * z2 * np.cos(alpha_rad) / 2
 
-    # Addendum circle radii
-    ra1 = m * (z1 / 2 + a1 + x1)
-    ra2 = m * (z2 / 2 + a1 + x2)
+    addendum_radius_gear1 = module * (z1 / 2 + a1 + x1)
+    addendum_radius_gear2 = module * (z2 / 2 + a1 + x2)
 
-    # Check for valid square root arguments
-    val1 = ra1**2 - rb1**2
-    val2 = ra2**2 - rb2**2
+    val1 = addendum_radius_gear1**2 - base_radius_gear1**2
+    val2 = addendum_radius_gear2**2 - base_radius_gear2**2
     if val1 < 0 or val2 < 0:
-        return 0, c # Cannot calculate contact ratio if addendum is below base circle
+        return 0.0, float(center_distance)
 
-    # Length of the path of contact
-    g_alpha = (np.sqrt(val1) + np.sqrt(val2)) - c * np.sin(alpha_w_rad)
+    path_of_contact = (np.sqrt(val1) + np.sqrt(val2)) - center_distance * np.sin(alpha_w_rad)
+    base_pitch = module * np.pi * np.cos(alpha_rad)
+    epsilon_alpha = path_of_contact / base_pitch
+    return float(epsilon_alpha), float(center_distance)
 
-    # Base pitch
-    pb = m * np.pi * np.cos(alpha_rad)
 
-    # Contact ratio
-    epsilon_alpha = g_alpha / pb
-    return epsilon_alpha, c
+def check_undercut(teeth: int, pressure_angle_deg: float, profile_shift: float, addendum: float) -> str:
+    """Assess whether a gear is at risk of undercutting."""
 
-def check_undercut(Z, ALPHA, X, A):
-    """Checks for undercut on a single gear."""
-    if Z <= 0:
+    if teeth <= 0:
         return "Not applicable for internal gears in this context"
-    alpha_rad = np.deg2rad(ALPHA)
-    # Minimum profile shift coefficient to avoid undercut
-    x_min = A - (Z / 2.0) * (np.sin(alpha_rad)**2)
-    if X < x_min:
+    alpha_rad = np.deg2rad(pressure_angle_deg)
+    x_min = addendum - (teeth / 2.0) * (np.sin(alpha_rad) ** 2)
+    if profile_shift < x_min:
         return f"Warning: Risk of undercut (x < {x_min:.3f})"
     return "OK"
 
-def handle_internal_gear_parameters(Z, X, B, A, D, C, E):
-    """Normalizes parameters for internal gears by inverting them."""
-    if Z < 0:
-        # For internal gears, conventions are often inverted
-        Z, X, B = -Z, -X, -B
-        A, D = D, A
-        C, E = E, C
-    return Z, X, B, A, D, C, E
 
-def calculate_gear_parameters(M, Z, ALPHA, X, B, A, D, C, E):
-    """
-    Calculates various geometric parameters and angles for tooth profile generation.
-    This function is complex and seems highly specific to the generating process.
-    """
-    ALPHA_0 = np.deg2rad(ALPHA)
-    ALPHA_M = np.pi / Z
-    ALPHA_IS = ALPHA_0 + np.pi / (2 * Z) + B / (Z * np.cos(ALPHA_0)) - (1 + 2 * X / Z) * np.sin(ALPHA_0) / np.cos(ALPHA_0)
-    THETA_IS = np.tan(ALPHA_0) + 2 * (C * (1 - np.sin(ALPHA_0)) + X - D) / (Z * np.cos(ALPHA_0) * np.sin(ALPHA_0))
+def handle_internal_gear_parameters(
+    teeth: int,
+    profile_shift: float,
+    backlash_factor: float,
+    addendum_factor: float,
+    dedendum_factor: float,
+    hob_edge_radius: float,
+    tooth_edge_radius: float,
+) -> Tuple[int, float, float, float, float, float, float]:
+    """Normalize the sign conventions for internal gears."""
 
-    sqrt_val_ie = ((Z + 2 * (X + A - E)) / (Z * np.cos(ALPHA_0)))**2 - 1
-    if sqrt_val_ie < 0:
-        sqrt_val_ie = 0
-    THETA_IE = 2 * E / (Z * np.cos(ALPHA_0)) + np.sqrt(sqrt_val_ie)
+    if teeth < 0:
+        teeth, profile_shift, backlash_factor = -teeth, -profile_shift, -backlash_factor
+        addendum_factor, dedendum_factor = dedendum_factor, addendum_factor
+        hob_edge_radius, tooth_edge_radius = tooth_edge_radius, hob_edge_radius
+    return (
+        int(teeth),
+        float(profile_shift),
+        float(backlash_factor),
+        float(addendum_factor),
+        float(dedendum_factor),
+        float(hob_edge_radius),
+        float(tooth_edge_radius),
+    )
 
-    sqrt_val_ae = ((Z + 2 * (X + A - E)) / (Z * np.cos(ALPHA_0)))**2 - 1
-    if sqrt_val_ae < 0:
-        sqrt_val_ae = 0
-    ALPHA_E = ALPHA_IS + THETA_IE - np.arctan(np.sqrt(sqrt_val_ae))
 
-    if (ALPHA_E > ALPHA_M) and (ALPHA_M > ALPHA_IS + THETA_IE - np.arctan(THETA_IE)):
-        sqrt_val_e = (1 / np.cos(ALPHA_IS + THETA_IE - ALPHA_M))**2 - 1
-        if sqrt_val_e < 0:
-            sqrt_val_e = 0
-        E = (E / 2) * np.cos(ALPHA_0) * (THETA_IE - np.sqrt(sqrt_val_e))
+def calculate_gear_parameters(
+    module: float,
+    teeth: int,
+    pressure_angle_deg: float,
+    profile_shift: float,
+    backlash_factor: float,
+    addendum_factor: float,
+    dedendum_factor: float,
+    hob_edge_radius: float,
+    tooth_edge_radius: float,
+) -> Tuple[float, float, float, float, float, float, float, float, float]:
+    """Derive the angular parameters used to build the tooth profile."""
 
-    P_ANGLE = 2 * np.pi / Z
-    ALIGN_ANGLE = np.pi / 2 - np.pi / Z
+    base_pressure_angle = np.deg2rad(pressure_angle_deg)
+    tooth_center_angle = np.pi / teeth
+    half_tooth_center_angle = tooth_center_angle / 2
+    pitch_angle = FULL_TURN / teeth
+    mid_tooth_angle = tooth_center_angle
+    involute_start_angle = (
+        base_pressure_angle
+        + half_tooth_center_angle
+        + backlash_factor / (teeth * np.cos(base_pressure_angle))
+        - (1 + 2 * profile_shift / teeth) * np.sin(base_pressure_angle) / np.cos(base_pressure_angle)
+    )
+    involute_theta_start = np.tan(base_pressure_angle) + 2 * (
+        hob_edge_radius * (1 - np.sin(base_pressure_angle)) + profile_shift - dedendum_factor
+    ) / (teeth * np.cos(base_pressure_angle) * np.sin(base_pressure_angle))
 
-    return ALPHA_0, ALPHA_M, ALPHA_IS, THETA_IS, THETA_IE, ALPHA_E, E, P_ANGLE, ALIGN_ANGLE
+    sqrt_val_ie = ((teeth + 2 * (profile_shift + addendum_factor - tooth_edge_radius)) / (teeth * np.cos(base_pressure_angle)))**2 - 1
+    sqrt_val_ie = max(sqrt_val_ie, 0)
+    involute_theta_end = 2 * tooth_edge_radius / (teeth * np.cos(base_pressure_angle)) + np.sqrt(sqrt_val_ie)
+
+    sqrt_val_ae = ((teeth + 2 * (profile_shift + addendum_factor - tooth_edge_radius)) / (teeth * np.cos(base_pressure_angle)))**2 - 1
+    sqrt_val_ae = max(sqrt_val_ae, 0)
+    edge_angle = involute_start_angle + involute_theta_end - np.arctan(np.sqrt(sqrt_val_ae))
+
+    if (edge_angle > mid_tooth_angle) and (mid_tooth_angle > involute_start_angle + involute_theta_end - np.arctan(involute_theta_end)):
+        sqrt_val_e = (1 / np.cos(involute_start_angle + involute_theta_end - mid_tooth_angle))**2 - 1
+        sqrt_val_e = max(sqrt_val_e, 0)
+        tooth_edge_radius = (tooth_edge_radius / 2) * np.cos(base_pressure_angle) * (involute_theta_end - np.sqrt(sqrt_val_e))
+
+    alignment_angle = RIGHT_ANGLE - tooth_center_angle
+
+    return (
+        float(base_pressure_angle),
+        float(mid_tooth_angle),
+        float(involute_start_angle),
+        float(involute_theta_start),
+        float(involute_theta_end),
+        float(edge_angle),
+        float(tooth_edge_radius),
+        float(pitch_angle),
+        float(alignment_angle),
+    )

--- a/fine_gear_profile_generator/core/geometry_generator.py
+++ b/fine_gear_profile_generator/core/geometry_generator.py
@@ -1,100 +1,362 @@
+"""Generate tooth geometry for spur gears."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
 import numpy as np
+
 from . import gear_math
 from . import transformations
 
-def involute_curve(M, Z, SEG_INVOLUTE, THETA_IS, THETA_IE, ALPHA_0, ALPHA_IS):
-    """Generates the involute part of the tooth flank."""
-    THETA1 = np.linspace(THETA_IS, THETA_IE, SEG_INVOLUTE)
-    X11 = (1/2) * M * Z * np.cos(ALPHA_0) * np.sqrt(1 + THETA1**2) * np.cos(ALPHA_IS + THETA1 - np.arctan(THETA1))
-    Y11 = (1/2) * M * Z * np.cos(ALPHA_0) * np.sqrt(1 + THETA1**2) * np.sin(ALPHA_IS + THETA1 - np.arctan(THETA1))
-    return X11, Y11
 
-def edge_round_curve(M, E, X11, Y11, X_E, Y_E, X_E0, Y_E0, SEG_EDGE_R):
-    """Generates the rounded edge curve at the tooth tip."""
-    THETA3_MIN = np.arctan2((Y11[-1] - Y_E0), (X11[-1] - X_E0))
-    THETA3_MAX = np.arctan2((Y_E - Y_E0), (X_E - X_E0))
-    THETA3 = np.linspace(THETA3_MIN, THETA3_MAX, SEG_EDGE_R)
-    X21 = M * E * np.cos(THETA3) + X_E0
-    Y21 = M * E * np.sin(THETA3) + Y_E0
-    return X21, Y21
+def involute_curve(
+    module: float,
+    teeth: int,
+    segment_count: int,
+    theta_start: float,
+    theta_end: float,
+    base_angle: float,
+    start_angle: float,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Generate the involute flank curve."""
 
-def root_round_curve(M, Z, X, D, C, B, THETA_TE, ALPHA_TS, SEG_ROOT_R):
-    """Generates the trochoidal root fillet curve."""
-    THETA_T = np.linspace(0, THETA_TE, SEG_ROOT_R)
-    denominator = M * D - M * X - M * C
-    if (C != 0) and (denominator == 0):
-        THETA_S = (np.pi / 2) * np.ones(len(THETA_T))
+    theta_values = np.linspace(theta_start, theta_end, segment_count)
+    radius = 0.5 * module * teeth * np.cos(base_angle) * np.sqrt(1 + theta_values**2)
+    x_coords = radius * np.cos(start_angle + theta_values - np.arctan(theta_values))
+    y_coords = radius * np.sin(start_angle + theta_values - np.arctan(theta_values))
+    return x_coords, y_coords
+
+
+def edge_round_curve(
+    module: float,
+    tooth_edge_radius: float,
+    flank_x: np.ndarray,
+    flank_y: np.ndarray,
+    edge_x: float,
+    edge_y: float,
+    edge_center_x: float,
+    edge_center_y: float,
+    segment_count: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Generate the rounded edge curve at the tooth tip."""
+
+    theta_min = np.arctan2((flank_y[-1] - edge_center_y), (flank_x[-1] - edge_center_x))
+    theta_max = np.arctan2((edge_y - edge_center_y), (edge_x - edge_center_x))
+    theta_values = np.linspace(theta_min, theta_max, segment_count)
+    x_coords = module * tooth_edge_radius * np.cos(theta_values) + edge_center_x
+    y_coords = module * tooth_edge_radius * np.sin(theta_values) + edge_center_y
+    return x_coords, y_coords
+
+
+def root_round_curve(
+    module: float,
+    teeth: int,
+    profile_shift: float,
+    dedendum_factor: float,
+    hob_edge_radius: float,
+    backlash_factor: float,
+    theta_end: float,
+    alpha_transition: float,
+    segment_count: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Generate the trochoidal root fillet curve."""
+
+    theta_values = np.linspace(0, theta_end, segment_count)
+    denominator = module * (dedendum_factor - profile_shift - hob_edge_radius)
+    if hob_edge_radius != 0 and denominator == 0:
+        theta_s = (np.pi / 2) * np.ones(len(theta_values))
     elif denominator != 0:
-        THETA_S = np.arctan((M * Z * THETA_T / 2) / denominator)
+        theta_s = np.arctan((module * teeth * theta_values / 2) / denominator)
     else:
-        THETA_S = np.zeros(len(THETA_T))
-    X31 = M * ((Z / 2 + X - D + C) * np.cos(THETA_T + ALPHA_TS) + (Z / 2) * THETA_T * np.sin(THETA_T + ALPHA_TS) - C * np.cos(THETA_S + THETA_T + ALPHA_TS))
-    Y31 = M * ((Z / 2 + X - D + C) * np.sin(THETA_T + ALPHA_TS) - (Z / 2) * THETA_T * np.cos(THETA_T + ALPHA_TS) - C * np.sin(THETA_S + THETA_T + ALPHA_TS))
-    return X31, Y31
+        theta_s = np.zeros(len(theta_values))
+    x_coords = module * (
+        (teeth / 2 + profile_shift - dedendum_factor + hob_edge_radius)
+        * np.cos(theta_values + alpha_transition)
+        + (teeth / 2)
+        * theta_values
+        * np.sin(theta_values + alpha_transition)
+        - hob_edge_radius * np.cos(theta_s + theta_values + alpha_transition)
+    )
+    y_coords = module * (
+        (teeth / 2 + profile_shift - dedendum_factor + hob_edge_radius)
+        * np.sin(theta_values + alpha_transition)
+        - (teeth / 2)
+        * theta_values
+        * np.cos(theta_values + alpha_transition)
+        - hob_edge_radius * np.sin(theta_s + theta_values + alpha_transition)
+    )
+    return x_coords, y_coords
 
-def outer_arc(M, Z, X, A, ALPHA_E, ALPHA_M, SEG_OUTER):
-    """Generates the outer arc at the tooth tip (addendum circle)."""
-    THETA6 = np.linspace(ALPHA_E, ALPHA_M, SEG_OUTER)
-    X41 = M * (Z / 2 + A + X) * np.cos(THETA6)
-    Y41 = M * (Z / 2 + A + X) * np.sin(THETA6)
-    return X41, Y41
 
-def root_arc(M, Z, X, D, ALPHA_TS, SEG_ROOT):
-    """Generates the root arc at the bottom of the tooth space (dedendum circle)."""
-    THETA7 = np.linspace(0, ALPHA_TS, SEG_ROOT)
-    X51 = M * (Z / 2 - D + X) * np.cos(THETA7)
-    Y51 = M * (Z / 2 - D + X) * np.sin(THETA7)
-    return X51, Y51
+def outer_arc(
+    module: float,
+    teeth: int,
+    profile_shift: float,
+    addendum_factor: float,
+    edge_angle: float,
+    mid_angle: float,
+    segment_count: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Generate the outer arc at the tooth tip (addendum circle)."""
 
-def combine_tooth_profile(X11, Y11, X21, Y21, X31, Y31, X41, Y41, X51, Y51, X12, Y12, X22, Y22, X32, Y32, X42, Y42, X52, Y52):
-    """Combines all curve segments into a single, continuous tooth profile."""
-    X1 = np.concatenate((X42[1:], X22[1:], X12[1:], X32[1:], X52[1:], X51, X31[1:], X11[1:], X21[1:], X41[1:]))
-    Y1 = np.concatenate((Y42[1:], Y22[1:], Y12[1:], Y32[1:], Y52[1:], Y51, Y31[1:], Y11[1:], Y21[1:], Y41[1:]))
-    return X1, Y1
+    theta_values = np.linspace(edge_angle, mid_angle, segment_count)
+    radius = module * (teeth / 2 + addendum_factor + profile_shift)
+    x_coords = radius * np.cos(theta_values)
+    y_coords = radius * np.sin(theta_values)
+    return x_coords, y_coords
 
-def generate_tooth_profile(M, Z, ALPHA, X, B, A, D, C, E, SEG_INVOLUTE, SEG_EDGE_R, SEG_ROOT_R, SEG_OUTER, SEG_ROOT):
-    """
-    Main function to generate a single gear tooth profile by calling all necessary
-    calculation and geometry generation sub-functions.
-    """
-    Z_calc, X_calc, B_calc, A_calc, D_calc, C_calc, E_calc = gear_math.handle_internal_gear_parameters(Z, X, B, A, D, C, E)
 
-    ALPHA_0, ALPHA_M, ALPHA_IS, THETA_IS, THETA_IE, ALPHA_E, E_calc, P_ANGLE, ALIGN_ANGLE = gear_math.calculate_gear_parameters(
-        M, Z_calc, ALPHA, X_calc, B_calc, A_calc, D_calc, C_calc, E_calc
+def root_arc(
+    module: float,
+    teeth: int,
+    profile_shift: float,
+    dedendum_factor: float,
+    transition_angle: float,
+    segment_count: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Generate the root arc at the bottom of the tooth space (dedendum circle)."""
+
+    theta_values = np.linspace(0, transition_angle, segment_count)
+    radius = module * (teeth / 2 - dedendum_factor + profile_shift)
+    x_coords = radius * np.cos(theta_values)
+    y_coords = radius * np.sin(theta_values)
+    return x_coords, y_coords
+
+
+def combine_tooth_profile(
+    flank1_x: np.ndarray,
+    flank1_y: np.ndarray,
+    edge1_x: np.ndarray,
+    edge1_y: np.ndarray,
+    root1_x: np.ndarray,
+    root1_y: np.ndarray,
+    outer1_x: np.ndarray,
+    outer1_y: np.ndarray,
+    root_arc1_x: np.ndarray,
+    root_arc1_y: np.ndarray,
+    flank2_x: np.ndarray,
+    flank2_y: np.ndarray,
+    edge2_x: np.ndarray,
+    edge2_y: np.ndarray,
+    root2_x: np.ndarray,
+    root2_y: np.ndarray,
+    outer2_x: np.ndarray,
+    outer2_y: np.ndarray,
+    root_arc2_x: np.ndarray,
+    root_arc2_y: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Combine all curve segments into a single continuous tooth profile."""
+
+    x_coords = np.concatenate(
+        (
+            outer2_x[1:],
+            edge2_x[1:],
+            flank2_x[1:],
+            root2_x[1:],
+            root_arc2_x[1:],
+            root_arc1_x,
+            root1_x[1:],
+            flank1_x[1:],
+            edge1_x[1:],
+            outer1_x[1:],
+        )
+    )
+    y_coords = np.concatenate(
+        (
+            outer2_y[1:],
+            edge2_y[1:],
+            flank2_y[1:],
+            root2_y[1:],
+            root_arc2_y[1:],
+            root_arc1_y,
+            root1_y[1:],
+            flank1_y[1:],
+            edge1_y[1:],
+            outer1_y[1:],
+        )
+    )
+    return x_coords, y_coords
+
+
+def _generate_tooth_profile_impl(
+    module: float,
+    teeth: int,
+    pressure_angle_deg: float,
+    profile_shift: float,
+    backlash_factor: float,
+    addendum_factor: float,
+    dedendum_factor: float,
+    hob_edge_radius: float,
+    tooth_edge_radius: float,
+    segments_involute: int,
+    segments_edge: int,
+    segments_root_round: int,
+    segments_outer: int,
+    segments_root: int,
+) -> Tuple[np.ndarray, np.ndarray, float, float, float]:
+    """Generate a single gear tooth profile with associated metadata."""
+
+    (teeth_calc, shift_calc, backlash_calc, addendum_calc, dedendum_calc,
+     hob_edge_calc, tooth_edge_calc) = gear_math.handle_internal_gear_parameters(
+        teeth, profile_shift, backlash_factor, addendum_factor, dedendum_factor, hob_edge_radius, tooth_edge_radius
     )
 
-    # Generate one flank of the tooth
-    X11, Y11 = involute_curve(M, Z_calc, SEG_INVOLUTE, THETA_IS, THETA_IE, ALPHA_0, ALPHA_IS)
-
-    # Generate the symmetrical other flank
-    X12, Y12 = transformations.reflect_y(X11, Y11)
-
-    # Calculate points for edge rounding
-    X_E = M * ((Z_calc / 2) + X_calc + A_calc) * np.cos(ALPHA_E)
-    Y_E = M * ((Z_calc / 2) + X_calc + A_calc) * np.sin(ALPHA_E)
-    X_E0 = M * (Z_calc / 2 + X_calc + A_calc - E_calc) * np.cos(ALPHA_E)
-    Y_E0 = M * (Z_calc / 2 + X_calc + A_calc - E_calc) * np.sin(ALPHA_E)
-
-    # Generate curve segments
-    X21, Y21 = edge_round_curve(M, E_calc, X11, Y11, X_E, Y_E, X_E0, Y_E0, SEG_EDGE_R)
-    X22, Y22 = transformations.reflect_y(X21, Y21)
-
-    ALPHA_TS = (2 * (C_calc * (1 - np.sin(ALPHA_0)) - D_calc) * np.sin(ALPHA_0) + B_calc) / (Z_calc * np.cos(ALPHA_0)) - 2 * C_calc * np.cos(ALPHA_0) / Z_calc + np.pi / (2 * Z_calc)
-    THETA_TE = 2 * C_calc * np.cos(ALPHA_0) / Z_calc - 2 * (D_calc - X_calc - C_calc * (1 - np.sin(ALPHA_0))) * np.cos(ALPHA_0) / (Z_calc * np.sin(ALPHA_0))
-
-    X31, Y31 = root_round_curve(M, Z_calc, X_calc, D_calc, C_calc, B_calc, THETA_TE, ALPHA_TS, SEG_ROOT_R)
-    X32, Y32 = transformations.reflect_y(X31, Y31)
-
-    X41, Y41 = outer_arc(M, Z_calc, X_calc, A_calc, ALPHA_E, ALPHA_M, SEG_OUTER)
-    X42, Y42 = transformations.reflect_y(X41, Y41)
-
-    X51, Y51 = root_arc(M, Z_calc, X_calc, D_calc, ALPHA_TS, SEG_ROOT)
-    X52, Y52 = transformations.reflect_y(X51, Y51)
-
-    # Combine all segments into a single tooth profile
-    X_tooth, Y_tooth = combine_tooth_profile(
-        X11, Y11, X21, Y21, X31, Y31, X41, Y41, X51, Y51,
-        X12, Y12, X22, Y22, X32, Y32, X42, Y42, X52, Y52
+    (
+        base_angle,
+        mid_angle,
+        involute_start_angle,
+        involute_theta_start,
+        involute_theta_end,
+        edge_angle,
+        tooth_edge_calc,
+        pitch_angle,
+        alignment_angle,
+    ) = gear_math.calculate_gear_parameters(
+        module,
+        teeth_calc,
+        pressure_angle_deg,
+        shift_calc,
+        backlash_calc,
+        addendum_calc,
+        dedendum_calc,
+        hob_edge_calc,
+        tooth_edge_calc,
     )
 
-    return X_tooth, Y_tooth, Z_calc, P_ANGLE, ALIGN_ANGLE
+    flank1_x, flank1_y = involute_curve(
+        module,
+        teeth_calc,
+        segments_involute,
+        involute_theta_start,
+        involute_theta_end,
+        base_angle,
+        involute_start_angle,
+    )
+    flank2_x, flank2_y = transformations.reflect_y(flank1_x, flank1_y)
+
+    edge_x = module * ((teeth_calc / 2) + shift_calc + addendum_calc) * np.cos(edge_angle)
+    edge_y = module * ((teeth_calc / 2) + shift_calc + addendum_calc) * np.sin(edge_angle)
+    edge_center_x = module * (teeth_calc / 2 + shift_calc + addendum_calc - tooth_edge_calc) * np.cos(edge_angle)
+    edge_center_y = module * (teeth_calc / 2 + shift_calc + addendum_calc - tooth_edge_calc) * np.sin(edge_angle)
+
+    edge1_x, edge1_y = edge_round_curve(
+        module,
+        tooth_edge_calc,
+        flank1_x,
+        flank1_y,
+        edge_x,
+        edge_y,
+        edge_center_x,
+        edge_center_y,
+        segments_edge,
+    )
+    edge2_x, edge2_y = transformations.reflect_y(edge1_x, edge1_y)
+
+    alpha_transition = (
+        (2 * (hob_edge_calc * (1 - np.sin(base_angle)) - dedendum_calc) * np.sin(base_angle) + backlash_calc)
+        / (teeth_calc * np.cos(base_angle))
+        - 2 * hob_edge_calc * np.cos(base_angle) / teeth_calc
+        + np.pi / (2 * teeth_calc)
+    )
+    theta_end = (
+        2 * hob_edge_calc * np.cos(base_angle) / teeth_calc
+        - 2 * (dedendum_calc - shift_calc - hob_edge_calc * (1 - np.sin(base_angle)))
+        * np.cos(base_angle)
+        / (teeth_calc * np.sin(base_angle))
+    )
+
+    root1_x, root1_y = root_round_curve(
+        module,
+        teeth_calc,
+        shift_calc,
+        dedendum_calc,
+        hob_edge_calc,
+        backlash_calc,
+        theta_end,
+        alpha_transition,
+        segments_root_round,
+    )
+    root2_x, root2_y = transformations.reflect_y(root1_x, root1_y)
+
+    outer1_x, outer1_y = outer_arc(
+        module,
+        teeth_calc,
+        shift_calc,
+        addendum_calc,
+        edge_angle,
+        mid_angle,
+        segments_outer,
+    )
+    outer2_x, outer2_y = transformations.reflect_y(outer1_x, outer1_y)
+
+    root_arc1_x, root_arc1_y = root_arc(
+        module,
+        teeth_calc,
+        shift_calc,
+        dedendum_calc,
+        alpha_transition,
+        segments_root,
+    )
+    root_arc2_x, root_arc2_y = transformations.reflect_y(root_arc1_x, root_arc1_y)
+
+    tooth_x, tooth_y = combine_tooth_profile(
+        flank1_x,
+        flank1_y,
+        edge1_x,
+        edge1_y,
+        root1_x,
+        root1_y,
+        outer1_x,
+        outer1_y,
+        root_arc1_x,
+        root_arc1_y,
+        flank2_x,
+        flank2_y,
+        edge2_x,
+        edge2_y,
+        root2_x,
+        root2_y,
+        outer2_x,
+        outer2_y,
+        root_arc2_x,
+        root_arc2_y,
+    )
+
+    return tooth_x, tooth_y, float(teeth_calc), float(pitch_angle), float(alignment_angle)
+
+
+def generate_tooth_profile(*args, **kwargs) -> Tuple[np.ndarray, np.ndarray, float, float, float]:
+    """Public wrapper supporting both legacy kwargs and new positional arguments."""
+
+    if kwargs:
+        key_map = {
+            'M': 'module',
+            'Z': 'teeth',
+            'ALPHA': 'pressure_angle_deg',
+            'X': 'profile_shift',
+            'B': 'backlash_factor',
+            'A': 'addendum_factor',
+            'D': 'dedendum_factor',
+            'C': 'hob_edge_radius',
+            'E': 'tooth_edge_radius',
+            'SEG_INVOLUTE': 'segments_involute',
+            'SEG_EDGE_R': 'segments_edge',
+            'SEG_ROOT_R': 'segments_root_round',
+            'SEG_OUTER': 'segments_outer',
+            'SEG_ROOT': 'segments_root',
+        }
+        normalized = {}
+        for legacy_key, new_key in key_map.items():
+            if legacy_key not in kwargs:
+                raise TypeError(f"Missing required parameter '{legacy_key}' for tooth profile generation")
+            normalized[new_key] = kwargs[legacy_key]
+        return _generate_tooth_profile_impl(**normalized)
+
+    expected_args = 13
+    if len(args) != expected_args:
+        raise TypeError(
+            "generate_tooth_profile() expects 13 positional arguments or legacy keyword arguments"
+        )
+
+    return _generate_tooth_profile_impl(*args)

--- a/fine_gear_profile_generator/core/geometry_generator.py
+++ b/fine_gear_profile_generator/core/geometry_generator.py
@@ -353,10 +353,10 @@ def generate_tooth_profile(*args, **kwargs) -> Tuple[np.ndarray, np.ndarray, flo
             normalized[new_key] = kwargs[legacy_key]
         return _generate_tooth_profile_impl(**normalized)
 
-    expected_args = 13
+    expected_args = 14
     if len(args) != expected_args:
         raise TypeError(
-            "generate_tooth_profile() expects 13 positional arguments or legacy keyword arguments"
+            "generate_tooth_profile() expects 14 positional arguments or legacy keyword arguments"
         )
 
     return _generate_tooth_profile_impl(*args)

--- a/fine_gear_profile_generator/core/models.py
+++ b/fine_gear_profile_generator/core/models.py
@@ -1,0 +1,181 @@
+"""Data models for the Fine Gear Profile Generator core layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+import numpy as np
+
+
+@dataclass
+class GearSpec:
+    """Specification for a single gear.
+
+    Attributes:
+        teeth: Number of teeth on the gear. The value must be non-zero so the
+            pitch angle can be derived.
+        profile_shift: Profile shift coefficient for the gear.
+    """
+
+    teeth: int
+    profile_shift: float
+
+    def __post_init__(self) -> None:
+        """Validate that the gear specification is internally consistent."""
+
+        if self.teeth == 0:
+            raise ValueError("Gear teeth count must be non-zero.")
+
+
+@dataclass
+class SegmentationSettings:
+    """Rendering segmentation resolution for generated tooth geometry."""
+
+    involute: int
+    edge: int
+    root_round: int
+    outer: int
+    root: int
+
+    def __post_init__(self) -> None:
+        """Ensure that the segmentation counts are strictly positive integers."""
+
+        for name, value in (
+            ("involute", self.involute),
+            ("edge", self.edge),
+            ("root_round", self.root_round),
+            ("outer", self.outer),
+            ("root", self.root),
+        ):
+            if value <= 0:
+                raise ValueError(f"Segmentation value '{name}' must be positive.")
+
+
+@dataclass
+class GearPairParameters:
+    """Aggregate configuration required to generate a meshing gear pair."""
+
+    module: float
+    pressure_angle_deg: float
+    backlash_factor: float
+    addendum_factor: float
+    dedendum_factor: float
+    hob_edge_radius: float
+    tooth_edge_radius: float
+    driver: GearSpec
+    driven: GearSpec
+    segmentation: SegmentationSettings
+    center_x: float = 0.0
+    center_y: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Validate scalar configuration values."""
+
+        if self.module <= 0:
+            raise ValueError("Module must be positive.")
+        if not 0 < self.pressure_angle_deg < 90:
+            raise ValueError("Pressure angle must be between 0 and 90 degrees.")
+
+    def to_calculation_dict(self) -> Dict[str, float]:
+        """Translate the dataclass into the dictionary form used by the engine."""
+
+        return {
+            "M": self.module,
+            "Z": self.driver.teeth,
+            "ALPHA": self.pressure_angle_deg,
+            "X": self.driver.profile_shift,
+            "B": self.backlash_factor,
+            "A": self.addendum_factor,
+            "D": self.dedendum_factor,
+            "C": self.hob_edge_radius,
+            "E": self.tooth_edge_radius,
+            "SEG_INVOLUTE": self.segmentation.involute,
+            "SEG_EDGE_R": self.segmentation.edge,
+            "SEG_ROOT_R": self.segmentation.root_round,
+            "SEG_OUTER": self.segmentation.outer,
+            "SEG_ROOT": self.segmentation.root,
+            "z2": self.driven.teeth,
+            "x2": self.driven.profile_shift,
+            "X_0": self.center_x,
+            "Y_0": self.center_y,
+        }
+
+    @classmethod
+    def from_dict(cls, params: Dict[str, float]) -> "GearPairParameters":
+        """Build an instance from the legacy dictionary representation."""
+
+        segmentation = SegmentationSettings(
+            involute=int(params["SEG_INVOLUTE"]),
+            edge=int(params["SEG_EDGE_R"]),
+            root_round=int(params["SEG_ROOT_R"]),
+            outer=int(params["SEG_OUTER"]),
+            root=int(params["SEG_ROOT"]),
+        )
+        return cls(
+            module=float(params["M"]),
+            pressure_angle_deg=float(params["ALPHA"]),
+            backlash_factor=float(params["B"]),
+            addendum_factor=float(params["A"]),
+            dedendum_factor=float(params["D"]),
+            hob_edge_radius=float(params["C"]),
+            tooth_edge_radius=float(params["E"]),
+            driver=GearSpec(teeth=int(params["Z"]), profile_shift=float(params["X"])),
+            driven=GearSpec(teeth=int(params["z2"]), profile_shift=float(params["x2"])),
+            segmentation=segmentation,
+            center_x=float(params.get("X_0", 0.0)),
+            center_y=float(params.get("Y_0", 0.0)),
+        )
+
+
+@dataclass
+class GearPairAnalysis:
+    """Calculated metrics that describe a gear pair's performance."""
+
+    contact_ratio: float
+    center_distance: float
+
+
+@dataclass
+class GearProfileGeometry:
+    """Generated geometric information for a single gear."""
+
+    coordinates: Tuple[np.ndarray, np.ndarray]
+    teeth: int
+    pitch_angle: float
+    alignment_angle: float
+    undercut_status: str
+
+    def as_tuple(self) -> Tuple[np.ndarray, np.ndarray, int, float, float]:
+        """Return a tuple formatted for the plotting and export utilities."""
+
+        x_coords, y_coords = self.coordinates
+        return x_coords, y_coords, self.teeth, self.pitch_angle, self.alignment_angle
+
+
+@dataclass
+class GearPairResult:
+    """Container bundling the geometry and analysis for a gear pair."""
+
+    analysis: GearPairAnalysis
+    gear1: GearProfileGeometry
+    gear2: GearProfileGeometry
+
+    def to_dict(self) -> Dict[str, Dict[str, object]]:
+        """Expose the result as a dictionary for backward compatibility."""
+
+        return {
+            "analysis": {
+                "contact_ratio": self.analysis.contact_ratio,
+                "center_distance": self.analysis.center_distance,
+            },
+            "gear1": {
+                "profile": self.gear1.as_tuple(),
+                "undercut_status": self.gear1.undercut_status,
+            },
+            "gear2": {
+                "profile": self.gear2.as_tuple(),
+                "undercut_status": self.gear2.undercut_status,
+            },
+        }
+

--- a/fine_gear_profile_generator/io/dxf_exporter.py
+++ b/fine_gear_profile_generator/io/dxf_exporter.py
@@ -1,50 +1,48 @@
+"""DXF export utilities for the Fine Gear Profile Generator."""
+
+from __future__ import annotations
+
+import os
+from typing import Tuple
+
 import ezdxf
 import numpy as np
-import os
+
 from ..core import transformations
 
-def export_gear_pair_to_dxf(working_dir, gear1_data, gear2_data, center_dist, x_offset, y_offset):
-    """
-    Exports a pair of gears to a DXF file.
+GearPlotTuple = Tuple[np.ndarray, np.ndarray, int, float, float]
 
-    Args:
-        working_dir (str): The directory to save the file in.
-        gear1_data (tuple): Contains (X_tooth, Y_tooth, Z, P_ANGLE, ALIGN_ANGLE) for gear 1.
-        gear2_data (tuple): Contains (X_tooth, Y_tooth, Z, P_ANGLE, ALIGN_ANGLE) for gear 2.
-        center_dist (float): The distance between the centers of the two gears.
-        x_offset (float): The X-coordinate of the center of the first gear.
-        y_offset (float): The Y-coordinate of the center of the first gear.
-    """
+
+def export_gear_pair_to_dxf(
+    working_dir: str,
+    gear1_data: GearPlotTuple,
+    gear2_data: GearPlotTuple,
+    center_dist: float,
+    x_offset: float,
+    y_offset: float,
+) -> None:
+    """Export the supplied gear pair geometry to a DXF file."""
+
     doc = ezdxf.new('R2000')
     msp = doc.modelspace()
 
-    # --- Draw Gear 1 ---
-    X_tooth1, Y_tooth1, Z1, P_ANGLE1, ALIGN_ANGLE1 = gear1_data
-    # First, align the tooth profile
-    X_rot1, Y_rot1 = transformations.rotate(X_tooth1, Y_tooth1, ALIGN_ANGLE1)
-    # Then, create the full gear by rotating the single tooth
-    for i in range(int(Z1)):
-        X_temp, Y_temp = transformations.rotate(X_rot1, Y_rot1, P_ANGLE1 * i)
-        # Finally, move the gear to its final position
-        X_final, Y_final = transformations.translate(X_temp, Y_temp, x_offset, y_offset)
-        msp.add_lwpolyline(list(zip(X_final, Y_final)), close=True, dxfattribs={'color': 5})  # Blue
+    x_tooth1, y_tooth1, z1, pitch_angle1, alignment_angle1 = gear1_data
+    x_rot1, y_rot1 = transformations.rotate(x_tooth1, y_tooth1, alignment_angle1)
+    for i in range(int(z1)):
+        x_temp, y_temp = transformations.rotate(x_rot1, y_rot1, pitch_angle1 * i)
+        x_final, y_final = transformations.translate(x_temp, y_temp, x_offset, y_offset)
+        msp.add_lwpolyline(list(zip(x_final, y_final)), close=True, dxfattribs={'color': 5})
 
-    # --- Draw Gear 2 ---
-    X_tooth2, Y_tooth2, Z2, P_ANGLE2, ALIGN_ANGLE2 = gear2_data
-    # The second gear needs an initial rotation to mesh correctly
-    initial_rotation2 = np.pi + (np.pi / Z2)
-    # First, align the tooth profile with the initial meshing rotation
-    X_rot2, Y_rot2 = transformations.rotate(X_tooth2, Y_tooth2, ALIGN_ANGLE2 + initial_rotation2)
-    # Then, create the full gear
-    for i in range(int(Z2)):
-        X_temp, Y_temp = transformations.rotate(X_rot2, Y_rot2, P_ANGLE2 * i)
-        # Finally, move the gear to its final position (offset by center distance)
-        X_final, Y_final = transformations.translate(X_temp, Y_temp, x_offset + center_dist, y_offset)
-        msp.add_lwpolyline(list(zip(X_final, Y_final)), close=True, dxfattribs={'color': 1})  # Red
+    x_tooth2, y_tooth2, z2, pitch_angle2, alignment_angle2 = gear2_data
+    initial_rotation2 = np.pi + (np.pi / z2)
+    x_rot2, y_rot2 = transformations.rotate(x_tooth2, y_tooth2, alignment_angle2 + initial_rotation2)
+    for i in range(int(z2)):
+        x_temp, y_temp = transformations.rotate(x_rot2, y_rot2, pitch_angle2 * i)
+        x_final, y_final = transformations.translate(x_temp, y_temp, x_offset + center_dist, y_offset)
+        msp.add_lwpolyline(list(zip(x_final, y_final)), close=True, dxfattribs={'color': 1})
 
-    # Save the DXF file
     output_path = os.path.join(working_dir, 'Result_Gear_Pair.dxf')
     try:
         doc.saveas(output_path)
-    except IOError:
+    except IOError:  # pragma: no cover - filesystem errors
         print(f"Error: Could not save DXF file to {output_path}.")

--- a/fine_gear_profile_generator/main.py
+++ b/fine_gear_profile_generator/main.py
@@ -1,82 +1,78 @@
+"""Entry point module for the Fine Gear Profile Generator application."""
+
+from __future__ import annotations
+
 import argparse
+import os
 import sys
 import tkinter as tk
-import os
+
+from typing import Optional
 
 # By using relative imports, we treat this project as a package.
 # This script should be run as a module from the parent directory, e.g.:
 # python -m fine_gear_profile_generator.main
 try:
     from .gui.fgpg_gui import GearApp
-    # In the future, headless mode would import from .core, .io, etc.
+    from .core import gear_core
+    from .io import dxf_exporter, image_exporter
+    from .utils import config_manager
 except ImportError:
     print("Error: Failed to import application modules.", file=sys.stderr)
     print("Please run this script as a module from the project's parent directory.", file=sys.stderr)
     print("Example: python -m fine_gear_profile_generator.main", file=sys.stderr)
     sys.exit(1)
 
-def run_headless_mode():
-    """
-    Runs the gear generation process with a default set of parameters,
-    saving the output files without launching the GUI.
-    """
+def run_headless_mode() -> None:
+    """Generate gears using default parameters without launching the GUI."""
+
     print("Running in headless mode with default parameters...")
 
-    # Default parameters, similar to the original script
-    params = {
-        'M': 1.0, 'Z': 18, 'ALPHA': 20.0, 'X': 0.2, 'B': 0.05, 'A': 1.0,
-        'D': 1.25, 'C': 0.2, 'E': 0.1, 'X_0': 0.0, 'Y_0': 0.0,
-        'SEG_INVOLUTE': 15, 'SEG_EDGE_R': 15, 'SEG_ROOT_R': 15,
-        'SEG_OUTER': 5, 'SEG_ROOT': 5,
-        'z2': 36, 'x2': 0.0
-    }
+    config_data = config_manager.load_app_config()
+    params = config_manager.get_default_gear_pair_parameters(config_data)
 
-    # Define the output directory relative to the project root
-    working_dir = os.path.join(os.path.dirname(__file__), 'result')
+    working_dir_default = config_manager.get_default_working_directory(config_data)
+    if os.path.isabs(working_dir_default):
+        working_dir = working_dir_default
+    else:
+        working_dir = os.path.join(os.path.dirname(__file__), working_dir_default)
     os.makedirs(working_dir, exist_ok=True)
 
     try:
-        from .core import gear_math, geometry_generator
-        from .io import dxf_exporter, image_exporter
+        result = gear_core.generate_gear_pair(params)
+        analysis = result.analysis
 
-        # --- Perform Calculations ---
-        contact_ratio, center_dist = gear_math.calculate_contact_ratio(
-            params['M'], params['Z'], params['z2'], params['X'], params['x2'], params['ALPHA'], params['A'])
-
-        # --- Generate Geometry ---
-        gear1_profile = geometry_generator.generate_tooth_profile(
-            params['M'], params['Z'], params['ALPHA'], params['X'], params['B'],
-            params['A'], params['D'], params['C'], params['E'],
-            params['SEG_INVOLUTE'], params['SEG_EDGE_R'], params['SEG_ROOT_R'],
-            params['SEG_OUTER'], params['SEG_ROOT'])
-
-        gear2_profile = geometry_generator.generate_tooth_profile(
-            params['M'], params['z2'], params['ALPHA'], params['x2'], params['B'],
-            params['A'], params['D'], params['C'], params['E'],
-            params['SEG_INVOLUTE'], params['SEG_EDGE_R'], params['SEG_ROOT_R'],
-            params['SEG_OUTER'], params['SEG_ROOT'])
-
-        # --- Export Files ---
         image_exporter.export_gear_pair_to_image(
-            working_dir, gear1_profile, gear2_profile, center_dist,
-            params['M'], params['Z'], params['z2'], params['X_0'], params['Y_0'])
+            working_dir,
+            result.gear1.as_tuple(),
+            result.gear2.as_tuple(),
+            analysis.center_distance,
+            params.module,
+            params.driver.teeth,
+            params.driven.teeth,
+            params.center_x,
+            params.center_y,
+        )
 
         dxf_exporter.export_gear_pair_to_dxf(
-            working_dir, gear1_profile, gear2_profile, center_dist,
-            params['X_0'], params['Y_0'])
+            working_dir,
+            result.gear1.as_tuple(),
+            result.gear2.as_tuple(),
+            analysis.center_distance,
+            params.center_x,
+            params.center_y,
+        )
 
         print(f"Headless run complete. Files saved in {working_dir}")
 
-    except Exception as e:
-        print(f"An error occurred during the headless run: {e}", file=sys.stderr)
+    except Exception as exc:
+        print(f"An error occurred during the headless run: {exc}", file=sys.stderr)
         sys.exit(1)
 
-def main():
-    """
-    Main entry point for the application.
-    Parses command-line arguments to decide whether to run the GUI
-    or a command-line version of the tool.
-    """
+
+def main(argv: Optional[list[str]] = None) -> None:
+    """Parse command-line arguments and execute the requested mode."""
+
     parser = argparse.ArgumentParser(
         description="A fine gear profile generator for spur and internal gears."
     )
@@ -88,7 +84,7 @@ def main():
     # Future arguments for headless mode would be defined here.
     # e.g., parser.add_argument('--module', type=float, help='Set the gear module.')
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.headless:
         run_headless_mode()

--- a/fine_gear_profile_generator/utils/config_manager.py
+++ b/fine_gear_profile_generator/utils/config_manager.py
@@ -1,45 +1,182 @@
+"""Helpers for loading and persisting Fine Gear Profile Generator settings."""
+
+from __future__ import annotations
+
 import json
 import os
+from typing import Dict, Tuple
 
-def save_params(working_dir, params_dict):
-    """
-    Saves a dictionary of parameters to Inputs.dat in the specified directory.
+from ..core.models import GearPairParameters, GearSpec, SegmentationSettings
 
-    Args:
-        working_dir (str): The directory where the file will be saved.
-        params_dict (dict): A dictionary containing the parameters to save.
-                            Keys are parameter names, values are the values.
-    """
+DEFAULT_CONFIG_FILENAME = 'config.json'
+
+FALLBACK_DEFAULTS = {
+    'module_m': 1.0,
+    'teeth_number_z': 18,
+    'pressure_angle_alpha': 20.0,
+    'offset_factor_x': 0.2,
+    'backlash_factor_b': 0.05,
+    'addendum_factor_a': 1.0,
+    'dedendum_factor_d': 1.25,
+    'hob_edge_radius_c': 0.2,
+    'tooth_edge_radius_e': 0.1,
+    'teeth_number_z2': 36,
+    'offset_factor_x2': 0.0,
+    'x_0': 0.0,
+    'y_0': 0.0,
+    'seg_involute': 15,
+    'seg_edge_r': 15,
+    'seg_root_r': 15,
+    'seg_outer': 5,
+    'seg_root': 5,
+    'working_directory': './result/',
+    'current_image_path': 'Result1.png'
+}
+
+UI_TO_CALCULATION_MAP = {
+    'module_m': 'M',
+    'teeth_number_z': 'Z',
+    'pressure_angle_alpha': 'ALPHA',
+    'offset_factor_x': 'X',
+    'backlash_factor_b': 'B',
+    'addendum_factor_a': 'A',
+    'dedendum_factor_d': 'D',
+    'hob_edge_radius_c': 'C',
+    'tooth_edge_radius_e': 'E',
+    'x_0': 'X_0',
+    'y_0': 'Y_0',
+    'seg_involute': 'SEG_INVOLUTE',
+    'seg_edge_r': 'SEG_EDGE_R',
+    'seg_root_r': 'SEG_ROOT_R',
+    'seg_outer': 'SEG_OUTER',
+    'seg_root': 'SEG_ROOT',
+    'teeth_number_z2': 'z2',
+    'offset_factor_x2': 'x2'
+}
+
+INT_PARAM_KEYS = {
+    'Z', 'SEG_INVOLUTE', 'SEG_EDGE_R', 'SEG_ROOT_R', 'SEG_OUTER',
+    'SEG_ROOT', 'z2'
+}
+
+
+def get_config_path(filename: str = DEFAULT_CONFIG_FILENAME) -> str:
+    """Return the absolute path to the application configuration file."""
+
+    package_root = os.path.dirname(os.path.dirname(__file__))
+    project_root = os.path.dirname(package_root)
+    return os.path.join(project_root, filename)
+
+
+def load_app_config(path: str | None = None) -> Dict[str, object]:
+    """Load application configuration data from JSON."""
+
+    config_path = path or get_config_path()
+    if not os.path.exists(config_path):
+        return {}
+    try:
+        with open(config_path, 'r', encoding='utf-8') as file:
+            return json.load(file)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def get_defaults(config_data: Dict[str, object] | None = None) -> Dict[str, object]:
+    """Return merged default values using configuration data with fallbacks."""
+
+    config = config_data or load_app_config()
+    defaults = dict(FALLBACK_DEFAULTS)
+    defaults.update(config.get('defaults', {}))
+    return defaults
+
+
+def _build_segmentation(defaults: Dict[str, object]) -> SegmentationSettings:
+    """Construct segmentation settings from the defaults table."""
+
+    return SegmentationSettings(
+        involute=int(defaults.get('seg_involute', FALLBACK_DEFAULTS['seg_involute'])),
+        edge=int(defaults.get('seg_edge_r', FALLBACK_DEFAULTS['seg_edge_r'])),
+        root_round=int(defaults.get('seg_root_r', FALLBACK_DEFAULTS['seg_root_r'])),
+        outer=int(defaults.get('seg_outer', FALLBACK_DEFAULTS['seg_outer'])),
+        root=int(defaults.get('seg_root', FALLBACK_DEFAULTS['seg_root'])),
+    )
+
+
+def _build_gear_specs(defaults: Dict[str, object]) -> Tuple[GearSpec, GearSpec]:
+    """Return driver and driven gear specifications."""
+
+    driver = GearSpec(
+        teeth=int(defaults.get('teeth_number_z', FALLBACK_DEFAULTS['teeth_number_z'])),
+        profile_shift=float(defaults.get('offset_factor_x', FALLBACK_DEFAULTS['offset_factor_x'])),
+    )
+    driven = GearSpec(
+        teeth=int(defaults.get('teeth_number_z2', FALLBACK_DEFAULTS['teeth_number_z2'])),
+        profile_shift=float(defaults.get('offset_factor_x2', FALLBACK_DEFAULTS['offset_factor_x2'])),
+    )
+    return driver, driven
+
+
+def get_default_gear_pair_parameters(config_data: Dict[str, object] | None = None) -> GearPairParameters:
+    """Build a ``GearPairParameters`` instance populated with default values."""
+
+    defaults = get_defaults(config_data)
+    segmentation = _build_segmentation(defaults)
+    driver, driven = _build_gear_specs(defaults)
+    return GearPairParameters(
+        module=float(defaults.get('module_m', FALLBACK_DEFAULTS['module_m'])),
+        pressure_angle_deg=float(defaults.get('pressure_angle_alpha', FALLBACK_DEFAULTS['pressure_angle_alpha'])),
+        backlash_factor=float(defaults.get('backlash_factor_b', FALLBACK_DEFAULTS['backlash_factor_b'])),
+        addendum_factor=float(defaults.get('addendum_factor_a', FALLBACK_DEFAULTS['addendum_factor_a'])),
+        dedendum_factor=float(defaults.get('dedendum_factor_d', FALLBACK_DEFAULTS['dedendum_factor_d'])),
+        hob_edge_radius=float(defaults.get('hob_edge_radius_c', FALLBACK_DEFAULTS['hob_edge_radius_c'])),
+        tooth_edge_radius=float(defaults.get('tooth_edge_radius_e', FALLBACK_DEFAULTS['tooth_edge_radius_e'])),
+        driver=driver,
+        driven=driven,
+        segmentation=segmentation,
+        center_x=float(defaults.get('x_0', FALLBACK_DEFAULTS['x_0'])),
+        center_y=float(defaults.get('y_0', FALLBACK_DEFAULTS['y_0'])),
+    )
+
+
+def get_default_calculation_params(config_data: Dict[str, object] | None = None) -> Dict[str, object]:
+    """Expose defaults using the legacy dictionary schema."""
+
+    params = get_default_gear_pair_parameters(config_data)
+    return params.to_calculation_dict()
+
+
+def get_default_working_directory(config_data: Dict[str, object] | None = None) -> str:
+    """Return the default working directory specified in the configuration."""
+
+    defaults = get_defaults(config_data)
+    return str(defaults.get('working_directory', FALLBACK_DEFAULTS['working_directory']))
+
+
+def save_params(working_dir: str, params_dict: Dict[str, object]) -> Tuple[bool, str]:
+    """Persist UI parameters to ``Inputs.dat`` in the specified directory."""
+
     os.makedirs(working_dir, exist_ok=True)
     filepath = os.path.join(working_dir, 'Inputs.dat')
     try:
-        with open(filepath, 'w') as f:
-            json.dump(params_dict, f, indent=4)
+        with open(filepath, 'w', encoding='utf-8') as file:
+            json.dump(params_dict, file, indent=4)
         return True, f"Parameters saved to {filepath}"
-    except Exception as e:
-        return False, f"Error saving parameters: {e}"
+    except OSError as error:
+        return False, f"Error saving parameters: {error}"
 
-def load_params(working_dir):
-    """
-    Loads parameters from Inputs.dat in the specified directory.
 
-    Args:
-        working_dir (str): The directory from which to load the file.
+def load_params(working_dir: str) -> Tuple[bool, Dict[str, object] | str]:
+    """Load parameters from ``Inputs.dat`` within the given directory."""
 
-    Returns:
-        A tuple (success, data_or_error_message).
-        If successful, (True, dict_of_parameters).
-        If failed, (False, error_message_string).
-    """
     filepath = os.path.join(working_dir, 'Inputs.dat')
     if not os.path.exists(filepath):
         return False, f"File not found: {filepath}"
 
     try:
-        with open(filepath, 'r') as f:
-            loaded_data = json.load(f)
+        with open(filepath, 'r', encoding='utf-8') as file:
+            loaded_data = json.load(file)
         return True, loaded_data
     except json.JSONDecodeError:
         return False, f"Error: The file {filepath} is not a valid JSON file."
-    except Exception as e:
-        return False, f"Failed to load parameters: {e}"
+    except OSError as error:
+        return False, f"Failed to load parameters: {error}"


### PR DESCRIPTION
## Summary
- add structured `GearSpec`, `SegmentationSettings`, and `GearPairParameters` dataclasses and refactor the core/configuration/GUI flows to consume typed parameter objects while remaining backward compatible with legacy dictionaries【F:fine_gear_profile_generator/core/models.py†L1-L181】【F:fine_gear_profile_generator/core/gear_core.py†L1-L84】【F:fine_gear_profile_generator/utils/config_manager.py†L1-L182】【F:fine_gear_profile_generator/gui/fgpg_gui.py†L1-L320】【F:fine_gear_profile_generator/main.py†L1-L103】
- document and type-hint the gear math and geometry modules, including a compatibility wrapper for the tooth profile generator that preserves existing test interfaces【F:fine_gear_profile_generator/core/gear_math.py†L1-L164】【F:fine_gear_profile_generator/core/geometry_generator.py†L1-L362】
- improve exporter modules with explicit types and docstrings to align with the refactored parameter objects【F:fine_gear_profile_generator/io/image_exporter.py†L1-L63】【F:fine_gear_profile_generator/io/dxf_exporter.py†L1-L48】

## Testing
- pytest【e6eecf†L1-L7】

------
https://chatgpt.com/codex/tasks/task_b_68e66e9536108328aa1b417cc6ddfc55